### PR TITLE
parse yaml markdown and interpret tags

### DIFF
--- a/crates/quarto-markdown-pandoc/src/pandoc/mod.rs
+++ b/crates/quarto-markdown-pandoc/src/pandoc/mod.rs
@@ -37,5 +37,5 @@ pub use crate::pandoc::table::{
 };
 
 pub use crate::pandoc::ast_context::ASTContext;
-pub use crate::pandoc::meta::{Meta, MetaValue, rawblock_to_meta};
+pub use crate::pandoc::meta::{Meta, MetaValue, parse_metadata_strings, rawblock_to_meta};
 pub use crate::pandoc::treesitter::treesitter_to_pandoc;

--- a/crates/quarto-markdown-pandoc/tests/test_meta.rs
+++ b/crates/quarto-markdown-pandoc/tests/test_meta.rs
@@ -3,8 +3,11 @@
  * Copyright (c) 2025 Posit, PBC
  */
 
+use hashlink::LinkedHashMap;
 use quarto_markdown_pandoc::pandoc::location::{Location, Range, SourceInfo};
-use quarto_markdown_pandoc::pandoc::{MetaValue, RawBlock, rawblock_to_meta};
+use quarto_markdown_pandoc::pandoc::{
+    Inline, MetaValue, RawBlock, parse_metadata_strings, rawblock_to_meta,
+};
 use std::fs;
 
 #[test]
@@ -53,4 +56,184 @@ fn test_metadata_parsing() {
         meta.get("typed_values"),
         Some(MetaValue::MetaList(_))
     ));
+}
+
+#[test]
+fn test_yaml_tagged_strings() {
+    // Test that YAML tags (!path, !glob, !str) prevent markdown parsing
+    let content = fs::read_to_string("tests/yaml-tagged-strings.qmd").unwrap();
+
+    let block = RawBlock {
+        format: "quarto_minus_metadata".to_string(),
+        text: content,
+        source_info: SourceInfo::with_range(Range {
+            start: Location {
+                offset: 0,
+                row: 0,
+                column: 0,
+            },
+            end: Location {
+                offset: 0,
+                row: 0,
+                column: 0,
+            },
+        }),
+    };
+
+    let mut meta = rawblock_to_meta(block);
+    let mut outer_meta = LinkedHashMap::new();
+
+    // Parse metadata strings
+    for (k, v) in meta.drain() {
+        let parsed = parse_metadata_strings(v, &mut outer_meta);
+        outer_meta.insert(k, parsed);
+    }
+
+    // Check plain_path - should be MetaInlines with Span wrapper
+    let plain_path = outer_meta.get("plain_path").expect("plain_path not found");
+    if let MetaValue::MetaInlines(inlines) = plain_path {
+        assert_eq!(inlines.len(), 1, "Expected exactly one inline");
+        if let Inline::Span(span) = &inlines[0] {
+            assert!(span.attr.1.contains(&"yaml-tagged-string".to_string()));
+            assert_eq!(span.attr.2.get("tag"), Some(&"path".to_string()));
+            // Extract the string content
+            if let Inline::Str(s) = &span.content[0] {
+                assert_eq!(s.text, "images/neovim-*.png");
+            } else {
+                panic!("Expected Str inline inside Span");
+            }
+        } else {
+            panic!("Expected Span inline, got: {:?}", inlines[0]);
+        }
+    } else {
+        panic!("Expected MetaInlines for plain_path");
+    }
+
+    // Check glob_pattern
+    let glob_pattern = outer_meta
+        .get("glob_pattern")
+        .expect("glob_pattern not found");
+    if let MetaValue::MetaInlines(inlines) = glob_pattern {
+        if let Inline::Span(span) = &inlines[0] {
+            assert_eq!(span.attr.2.get("tag"), Some(&"glob".to_string()));
+            if let Inline::Str(s) = &span.content[0] {
+                assert_eq!(s.text, "posts/*/index.qmd");
+            }
+        }
+    }
+
+    // Check literal_string
+    let literal_string = outer_meta
+        .get("literal_string")
+        .expect("literal_string not found");
+    if let MetaValue::MetaInlines(inlines) = literal_string {
+        if let Inline::Span(span) = &inlines[0] {
+            assert_eq!(span.attr.2.get("tag"), Some(&"str".to_string()));
+            if let Inline::Str(s) = &span.content[0] {
+                assert_eq!(s.text, "_foo_.py");
+            }
+        }
+    }
+
+    // Check regular_markdown - should have parsed markdown (Emph element)
+    let regular_markdown = outer_meta
+        .get("regular_markdown")
+        .expect("regular_markdown not found");
+    if let MetaValue::MetaInlines(inlines) = regular_markdown {
+        // Should contain Emph for *emphasis*
+        let has_emph = inlines
+            .iter()
+            .any(|inline| matches!(inline, Inline::Emph(_)));
+        assert!(
+            has_emph,
+            "regular_markdown should have Emph element from *emphasis*"
+        );
+    } else {
+        panic!("Expected MetaInlines for regular_markdown");
+    }
+}
+
+#[test]
+fn test_yaml_markdown_parse_failure() {
+    // Test that untagged strings that fail markdown parsing are gracefully handled
+    let content = fs::read_to_string("tests/yaml-markdown-parse-failure.qmd").unwrap();
+
+    let block = RawBlock {
+        format: "quarto_minus_metadata".to_string(),
+        text: content,
+        source_info: SourceInfo::with_range(Range {
+            start: Location {
+                offset: 0,
+                row: 0,
+                column: 0,
+            },
+            end: Location {
+                offset: 0,
+                row: 0,
+                column: 0,
+            },
+        }),
+    };
+
+    let mut meta = rawblock_to_meta(block);
+    let mut outer_meta = LinkedHashMap::new();
+
+    // Parse metadata strings - this should not panic
+    for (k, v) in meta.drain() {
+        let parsed = parse_metadata_strings(v, &mut outer_meta);
+        outer_meta.insert(k, parsed);
+    }
+
+    // Check untagged_path - should be wrapped in error span
+    let untagged_path = outer_meta
+        .get("untagged_path")
+        .expect("untagged_path not found");
+    if let MetaValue::MetaInlines(inlines) = untagged_path {
+        if let Inline::Span(span) = &inlines[0] {
+            assert!(
+                span.attr
+                    .1
+                    .contains(&"yaml-markdown-syntax-error".to_string())
+            );
+            if let Inline::Str(s) = &span.content[0] {
+                assert_eq!(s.text, "posts/*/index.qmd");
+            }
+        } else {
+            panic!("Expected Span inline for failed parse");
+        }
+    } else {
+        panic!("Expected MetaInlines for untagged_path");
+    }
+
+    // Check another_glob - should also be wrapped in error span
+    let another_glob = outer_meta
+        .get("another_glob")
+        .expect("another_glob not found");
+    if let MetaValue::MetaInlines(inlines) = another_glob {
+        if let Inline::Span(span) = &inlines[0] {
+            assert!(
+                span.attr
+                    .1
+                    .contains(&"yaml-markdown-syntax-error".to_string())
+            );
+            if let Inline::Str(s) = &span.content[0] {
+                assert_eq!(s.text, "images/*.png");
+            }
+        }
+    }
+
+    // Check underscore_file - this one should successfully parse as markdown with Emph
+    let underscore_file = outer_meta
+        .get("underscore_file")
+        .expect("underscore_file not found");
+    if let MetaValue::MetaInlines(inlines) = underscore_file {
+        // _foo_ should become Emph element
+        let has_emph = inlines
+            .iter()
+            .any(|inline| matches!(inline, Inline::Emph(_)));
+        assert!(
+            has_emph,
+            "underscore_file should have Emph element from _foo_"
+        );
+    }
 }

--- a/crates/quarto-markdown-pandoc/tests/yaml-markdown-parse-failure.qmd
+++ b/crates/quarto-markdown-pandoc/tests/yaml-markdown-parse-failure.qmd
@@ -1,0 +1,8 @@
+---
+title: Test Markdown Parse Failure Fallback
+untagged_path: posts/*/index.qmd
+another_glob: images/*.png
+underscore_file: _foo_.py
+---
+
+Test document for graceful handling of markdown parse failures in untagged strings.

--- a/crates/quarto-markdown-pandoc/tests/yaml-tagged-strings.qmd
+++ b/crates/quarto-markdown-pandoc/tests/yaml-tagged-strings.qmd
@@ -1,0 +1,9 @@
+---
+title: Test YAML Tagged Strings
+plain_path: !path images/neovim-*.png
+glob_pattern: !glob posts/*/index.qmd
+literal_string: !str _foo_.py
+regular_markdown: This has *emphasis*
+---
+
+Test document for YAML tag support.

--- a/docs/syntax/index.qmd
+++ b/docs/syntax/index.qmd
@@ -13,3 +13,4 @@ The features documented here are currently under development. The syntax and beh
 - [Definition Lists](definition-lists.qmd) - Create definition lists using an embedded markdown DSL
 - [Editorial Marks](editorial-marks.qmd) - Annotate text with highlights, insertions, deletions, and comments
 - [Footnotes](footnotes.qmd) - Add footnotes with inline or fenced block syntax
+- [YAML Metadata](yaml-metadata.qmd) - Control markdown parsing in metadata with YAML tags

--- a/docs/syntax/yaml-metadata.qmd
+++ b/docs/syntax/yaml-metadata.qmd
@@ -1,0 +1,242 @@
+---
+title: "YAML Metadata"
+---
+
+## Overview
+
+YAML front matter provides document-level metadata in Quarto documents. In `quarto-markdown`, metadata values are parsed as markdown by default, allowing you to use formatting like `*emphasis*` and `[links](url)`. However, some values—like file paths and glob patterns—should be treated as literal strings.
+
+## Default Behavior: Markdown Parsing
+
+By default, string values in YAML metadata are parsed as markdown:
+
+```yaml
+---
+title: This has *emphasis*
+description: Visit [our website](https://example.com) for more info
+---
+```
+
+The `title` will render with italicized "emphasis", and the `description` will include a clickable link.
+
+## YAML Tags for Literal Strings
+
+When you need to prevent markdown parsing, use YAML tags to mark values as literal strings:
+
+### Available Tags
+
+- `!str` - Plain string, no markdown parsing
+- `!path` - File path (same as `!str`, but semantically clearer)
+- `!glob` - Glob pattern (same as `!str`, but semantically clearer)
+
+### Syntax
+
+Prefix the value with the tag:
+
+```yaml
+---
+title: My Blog
+resources:
+  - !path images/neovim-*.png
+  - !path _foo_.py
+listing:
+  contents: !glob posts/*/index.qmd
+plain: !str "Text with * and _ chars that won't be parsed"
+---
+```
+
+## Why Use Tags?
+
+### Problem: Wildcard Characters
+
+File paths and glob patterns often contain characters that have special meaning in markdown:
+
+- `*` - Indicates emphasis in markdown
+- `_` - Also indicates emphasis in markdown
+- `[` and `]` - Indicate links in markdown
+
+Without tags, these can cause unexpected results:
+
+```yaml
+---
+# Without tag: _foo_.py is parsed as markdown
+# The underscore characters create italic emphasis!
+file: _foo_.py  # Parsed as: <em>foo</em>.py
+
+# With tag: preserved literally
+file: !path _foo_.py  # Parsed as: "_foo_.py"
+---
+```
+
+### Examples Where Tags Help
+
+**Glob patterns with wildcards:**
+
+```yaml
+---
+# ❌ Without tag: asterisk triggers markdown parsing error
+listing: posts/*/index.qmd
+
+# ✅ With tag: preserved as literal glob pattern
+listing: !glob posts/*/index.qmd
+---
+```
+
+**File paths with underscores:**
+
+```yaml
+---
+# ❌ Without tag: underscores create italic emphasis
+script: _build_helper.py  # Parsed as: <em>build</em>helper.py
+
+# ✅ With tag: preserved as literal file path
+script: !path _build_helper.py
+---
+```
+
+**Relative paths:**
+
+```yaml
+---
+# ❌ Without tag: parsed as markdown, leading dots may confuse parser
+redirect: ../_redirect.html
+
+# ✅ With tag: preserved as literal path
+redirect: !path ../_redirect.html
+---
+```
+
+## Graceful Fallback
+
+If a string fails to parse as markdown (e.g., because it contains `*` wildcard characters), `quarto-markdown` will gracefully preserve it as a literal string instead of crashing.
+
+The parser wraps failed parses in a special marker that downstream tools can detect:
+
+```json
+{
+  "t": "MetaInlines",
+  "c": [{
+    "t": "Span",
+    "c": [
+      ["", ["yaml-markdown-syntax-error"], []],
+      [{"t": "Str", "c": "posts/*/index.qmd"}]
+    ]
+  }]
+}
+```
+
+While this graceful fallback prevents crashes, using explicit tags is better practice:
+
+1. **Intent**: Tags clearly communicate that a value should be literal
+2. **Reliability**: Tags work even if the string happens to be valid markdown
+3. **Tooling**: Downstream tools can recognize tagged strings by the `yaml-tagged-string` class
+
+## When to Use Tags
+
+Use YAML tags when metadata values contain:
+
+- **File paths**: Especially those with wildcards, underscores, or special characters
+- **Glob patterns**: Any pattern using `*`, `?`, or `[...]` syntax
+- **Configuration strings**: Technical strings that shouldn't be formatted
+
+**Don't need tags** for:
+
+- **Titles and descriptions**: Where you want markdown formatting
+- **Plain text**: Simple strings without special characters
+- **Booleans and numbers**: These are never parsed as markdown
+
+## Complete Example
+
+```yaml
+---
+title: My Data Science Blog
+description: Articles about *statistics* and [machine learning](ml.html)
+
+# File paths with wildcards - use tags
+resources:
+  - !path images/*.png
+  - !path data/**/*.csv
+  - !path _utils.py
+
+# Glob patterns - use tags
+listing:
+  contents: !glob posts/*/index.qmd
+
+# Configuration strings - use tags
+redirect: !path ../index.html
+template: !str {{< special-syntax >}}
+
+# Regular strings - no tags needed
+author: Jane Doe
+date: 2024-01-15
+---
+```
+
+## Implementation Details
+
+### Tagged String Representation
+
+Tagged strings are converted to Pandoc's `MetaInlines` with a `Span` wrapper:
+
+```json
+{
+  "t": "MetaInlines",
+  "c": [{
+    "t": "Span",
+    "c": [
+      ["", ["yaml-tagged-string"], [["tag", "path"]]],
+      [{"t": "Str", "c": "images/neovim-*.png"}]
+    ]
+  }]
+}
+```
+
+The representation includes:
+
+- **Class**: `yaml-tagged-string` - Identifies this as a tagged value
+- **Attribute**: `tag` - Contains the tag name (`str`, `path`, or `glob`)
+- **Content**: The literal string value wrapped in a `Str` inline
+
+### Compatibility with Pandoc
+
+Tagged strings are compatible with Pandoc's Lua filter API:
+
+```lua
+-- Extract the string value
+local value = pandoc.utils.stringify(meta.listing.contents)
+-- value == "posts/*/index.qmd"
+
+-- Check if it's a tagged string
+if meta.listing.contents[1].classes[1] == "yaml-tagged-string" then
+  local tag = meta.listing.contents[1].attributes.tag
+  -- tag == "glob"
+end
+```
+
+The `pandoc.utils.stringify()` function correctly extracts the string content, so most filters will work without modification.
+
+## Migration Guide
+
+If you have existing documents that are failing to parse due to file paths or glob patterns:
+
+1. **Identify problematic values**: Look for metadata with `*`, `_`, or other markdown special characters
+2. **Add tags**: Prefix those values with `!path`, `!glob`, or `!str`
+3. **Test**: Verify the document parses without errors
+
+Example migration:
+
+```yaml
+# Before (may crash or parse incorrectly)
+---
+listing: posts/*/index.qmd
+resources: [images/*.png, _helper.py]
+---
+
+# After (explicit and reliable)
+---
+listing: !glob posts/*/index.qmd
+resources:
+  - !path images/*.png
+  - !path _helper.py
+---
+```


### PR DESCRIPTION
This fixes the following problem:

```
---
resources: 
  - file*.qmd
---
```

In Pandoc, that asterisk is just an asterisk because the attempt to parse an emphasis fails, and Pandoc falls back to adding "*". That's not how QMD will work. We _want_ syntax errors. But then, how do you we support glob syntax in an ergonomic way?

This PR has a solution, and the docs explain.