### PR TITLE
put URL diagnostic reporting behind a cfg gate

### DIFF
--- a/crates/quarto-error-reporting/src/lib.rs
+++ b/crates/quarto-error-reporting/src/lib.rs
@@ -64,4 +64,6 @@ pub mod macros;
 // Re-export main types for convenience
 pub use builder::DiagnosticMessageBuilder;
 pub use catalog::{ERROR_CATALOG, ErrorCodeInfo, get_docs_url, get_error_info, get_subsystem};
-pub use diagnostic::{DetailItem, DetailKind, DiagnosticKind, DiagnosticMessage, MessageContent, TextRenderOptions};
+pub use diagnostic::{
+    DetailItem, DetailKind, DiagnosticKind, DiagnosticMessage, MessageContent, TextRenderOptions,
+};


### PR DESCRIPTION
This should allow us to generate a WASM library again.